### PR TITLE
Pin Julia version to 1.8.3

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.7'
+          - '1.8'
         os:
           - ubuntu-latest
         arch:

--- a/Project.toml
+++ b/Project.toml
@@ -36,7 +36,7 @@ OffsetArrays = "1.12.8"
 Plots = "1.25.8"
 StaticArrays = "1.4.4"
 WebIO = "0.8.17"
-julia = "1.7"
+julia = "1.8.3"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Fibers.jl does not work on Julia 1.7. I got it to work on Julia 1.8.3, thus I'm suggesting to pin this version in the current code.